### PR TITLE
Hide mobile menu items

### DIFF
--- a/theme/sections/faq.liquid
+++ b/theme/sections/faq.liquid
@@ -1,0 +1,145 @@
+<section class="faq-mat page-width">
+  <h2 class="faq-title">Frequently Asked Questions</h2>
+  <div class="faq-list">
+    <div class="faq-item">
+      <button class="faq-question">How does private tutoring work?</button>
+      <div class="faq-answer">
+        <p>Private tutoring provides you with 1-on-1 lessons tailored to your needs. You choose the time, your tutor creates a plan just for you.</p>
+      </div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question">Who are the tutors?</button>
+      <div class="faq-answer">
+        <p>All tutors are certified, experienced professionals — many are native speakers. You can view profiles and choose your preferred coach.</p>
+      </div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question">What if I need to reschedule a lesson?</button>
+      <div class="faq-answer">
+        <p>No problem! You can reschedule any session up to 12 hours before the lesson, directly from your dashboard or by contacting us.</p>
+      </div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question">Are all materials included?</button>
+      <div class="faq-answer">
+        <p>Yes, all digital materials and homework are included. You’ll also get access to recordings and extra practice activities.</p>
+      </div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question">Can I get a refund if I’m not satisfied?</button>
+      <div class="faq-answer">
+        <p>Absolutely. If you’re not happy after your first lesson, we’ll refund your payment. No questions asked!</p>
+      </div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question">How do I start?</button>
+      <div class="faq-answer">
+        <p>Choose your plan, complete the booking, and we’ll connect you with your personal tutor. All details by email!</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<style>
+.faq-mat {
+  background: #fff;
+  box-shadow: none;
+  border-radius: 0 !important;
+  border: 1.5px solid #e4e7f0;
+  padding: 2.3rem 2.4rem 1.4rem 2.4rem;
+}
+.faq-title {
+  text-align: center;
+  color: #4e54c8;
+  font-size: 1.39rem;
+  margin-bottom: 1.1rem;
+  font-weight: 800;
+}
+.faq-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+.faq-item {
+  background: #fff;
+  border-radius: 0 !important;
+  margin-bottom: 0;
+  border: 1.5px solid #e4e7f0;
+  box-shadow: none;
+  transition: none;
+}
+.faq-item.open, .faq-item:hover {
+  background: #f7faff;
+}
+.faq-question {
+  width: 100%;
+  background: none;
+  border: none;
+  outline: none;
+  font-size: 1.04rem;
+  font-weight: 600;
+  color: #222b58;
+  padding: 0.95rem 1.5rem 0.95rem 1.1rem;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 0 !important;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  position: relative;
+}
+.faq-question:after {
+  content: "\25BC";
+  font-size: 0.97rem;
+  color: #8f94fb;
+  position: absolute;
+  right: 1.15rem;
+  transition: transform 0.18s;
+}
+.faq-item.open .faq-question:after {
+  transform: rotate(-180deg);
+}
+.faq-answer {
+  max-height: 0;
+  overflow: hidden;
+  background: none;
+  transition: max-height 0.19s cubic-bezier(0.67,0,0.33,1), padding 0.19s;
+  padding: 0 1.2rem;
+  color: #384060;
+}
+.faq-item.open .faq-answer {
+  max-height: 190px;
+  padding: 0 1.2rem 0.6rem 1.2rem;
+}
+.faq-answer p {
+  margin: 0;
+  font-size: 0.99rem;
+  color: #384060;
+}
+@media (max-width: 900px) {
+  .faq-mat { padding: 1.2rem 1rem 0.7rem 1rem; }
+}
+@media (max-width: 600px) {
+  .faq-mat { padding: 0.9rem 0.3rem 0.5rem 0.3rem; }
+}
+</style>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  document.querySelectorAll('.faq-question').forEach(btn => {
+    btn.addEventListener('click', function() {
+      const item = this.parentElement;
+      const open = item.classList.contains('open');
+      document.querySelectorAll('.faq-item').forEach(f => f.classList.remove('open'));
+      if(!open) item.classList.add('open');
+    });
+  });
+});
+</script>
+
+{% schema %}
+{
+  "name": "Frequently Asked Questions",
+  "settings": []
+}
+{% endschema %}

--- a/theme/sections/group-classes.liquid
+++ b/theme/sections/group-classes.liquid
@@ -1,0 +1,270 @@
+<section class="group-classes-hero-bg">
+  <div class="group-classes-hero page-width">
+    <div class="group-classes-hero__main">
+      <!-- SOL: Bilgi -->
+      <div class="group-classes-hero__content">
+        <h1>Group Classes</h1>
+        <p>
+          Join interactive lessons with peers and stay motivated together.<br>          Certified instructors guide you through each session.
+        </p>
+        <ul class="features">
+          <li>Engaging group environment</li>
+          <li>Experienced instructors</li>
+          <li>60-minute live sessions</li>
+          <li>Learn from peers</li>
+          <li>Resources included</li>
+          <li>Track progress together</li>
+        </ul>
+        <div class="info-note">
+          <small>Questions? <a href="/contact">Contact us</a> for custom plans!</small>
+        </div>
+      </div>
+      <!-- SAĞ: Görsel + Checkout Cart + Dışarıda Buton -->
+      <div class="group-classes-hero__visual">
+        <img class="group-classes-hero__image" src="https://cdn.shopify.com/s/files/1/0759/1546/0848/files/ChatGPT_Image_7_Tem_2025_15_58_34.png?v=1751893408" alt="Online English Tutoring, AI generated" loading="lazy" />
+        <div class="group-classes-cart-box">
+          <div class="cart-title">Your Selection</div>
+          <div class="cart-package"><strong>Group Classes</strong></div>
+          <div class="cart-plan">Plan: <span id="cartPlanName">Monthly</span></div>
+          <div class="cart-price" id="cartPrice">$49.99</div>
+          <ul class="cart-benefits">
+            <li>Up to 10 students</li>
+            <li>Interactive class</li>
+            <li>Fixed weekly schedule</li>
+            <li>Materials included</li>
+          </ul>
+          <div class="cart-note">
+            <small>* All prices include VAT. Each session is 60 minutes.</small>
+          </div>
+        </div>
+        <!-- Buton KUTUNUN DIŞINDA ve köşeli -->
+        <a id="checkoutBtn" href="/checkout" class="button checkout-mat">Proceed to Checkout</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+<style>
+body {
+  background: linear-gradient(120deg, #f7faff 0%, #edf1fc 42%, #e6eafb 100%) !important;
+}
+.group-classes-hero-bg {
+  background: linear-gradient(105deg, #ffffff 60%, #e7e9fb 100%);
+  min-height: 80vh;
+  padding-top: 40px;
+  padding-bottom: 0;
+}
+.group-classes-hero {
+  max-width: 1160px;
+  margin: 0 auto;
+  padding: 0 12px;
+}
+.group-classes-hero__main {
+  display: flex;
+  gap: 40px;
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+.group-classes-hero__content {
+  flex: 2 1 430px;
+  min-width: 320px;
+  max-width: 600px;
+  padding: 2.3rem 1.3rem 2.1rem 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  background: none;
+}
+.group-classes-hero__content h1 {
+  font-size: 2.3rem;
+  font-weight: 800;
+  color: #21264b;
+  margin-bottom: 0.8rem;
+}
+.group-classes-hero__content p {
+  font-size: 1.18rem;
+  color: #31315b;
+  margin-bottom: 1.3rem;
+}
+.features {
+  list-style: none;
+  padding: 0;
+  margin: 1.1rem 0 1.1rem 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem 1.7rem;
+}
+.features li {
+  position: relative;
+  padding-left: 1.23rem;
+  font-size: 1.05rem;
+  color: #28305e;
+  flex: 0 0 220px;
+  margin-bottom: 0.2rem;
+}
+.features li:before {
+  content: "✔";
+  position: absolute;
+  left: 0;
+  color: #4e54c8;
+  font-weight: bold;
+  font-size: 1rem;
+}
+.info-note {
+  margin-top: 0.6rem;
+  color: #4e54c8;
+  font-size: 0.96rem;
+}
+
+/* --- VISUAL SIDE --- */
+.group-classes-hero__visual {
+  flex: 1 1 380px;
+  min-width: 290px;
+  max-width: 420px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2.1rem;
+}
+.group-classes-hero__image {
+  width: 100%;
+  max-width: 340px;
+  object-fit: cover;
+  background: #f8fafc;
+  margin-bottom: 0.5rem;
+  /* Köşeli ve gölgesiz! */
+  border-radius: 0 !important;
+  box-shadow: none !important;
+}
+.group-classes-cart-box {
+  width: 100%;
+  max-width: 340px;
+  padding: 2rem 1.6rem 1.5rem 1.6rem;
+  background: #fff;
+  box-shadow: none;
+  border-radius: 0 !important;
+  border: 1.5px solid #e4e7f0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  margin-top: 0;
+  margin-bottom: 1.15rem;
+}
+.cart-title {
+  font-size: 1.12rem;
+  font-weight: 700;
+  color: #4e54c8;
+  margin-bottom: 0.7rem;
+}
+.cart-package { font-size: 1.09rem; font-weight: 600; color: #23235b; margin-bottom: 0.3rem; }
+.cart-plan { margin-bottom: 0.3rem; font-size: 1.01rem; color: #28305e; }
+.cart-price {
+  font-size: 1.28rem;
+  font-weight: 800;
+  color: #4e54c8;
+  margin-bottom: 1rem;
+  background: none;
+  -webkit-background-clip: initial;
+  -webkit-text-fill-color: initial;
+}
+.cart-benefits {
+  list-style: none;
+  margin: 0 0 0.7rem 0;
+  padding: 0;
+  font-size: 0.98rem;
+}
+.cart-benefits li {
+  position: relative;
+  padding-left: 1.2rem;
+  margin-bottom: 0.3rem;
+  color: #444;
+}
+.cart-benefits li:before { content: "–"; position: absolute; left: 0; color: #8f94fb;}
+.cart-note { font-size: 0.93rem; color: #555; margin-top: 0.1rem;}
+.cart-note a { color: #4e54c8; }
+
+/* --- BUTON TAM KÖŞELİ, BEYAZ, FLICKER EFFECT --- */
+.button.checkout-mat {
+  margin-top: 16px;
+  display: block;
+  width: 100%;
+  max-width: 340px;
+  height: 56px;
+  line-height: 56px;
+  text-align: center;
+  font-size: 1.13rem;
+  font-weight: 700;
+  background: #fff;
+  color: #4e54c8;
+  border: 2px solid #4e54c8;
+  border-radius: 0;
+  box-shadow: none;
+  cursor: pointer;
+  letter-spacing: 0.01em;
+  outline: none;
+  position: relative;
+  overflow: hidden;
+  transition: color 0.18s, border-color 0.22s, background 0.20s;
+}
+.button.checkout-mat:after {
+  content: "";
+  position: absolute;
+  top: 0; left: -60px;
+  width: 45px; height: 100%;
+  background: linear-gradient(100deg,rgba(76,107,255,0.12) 0%,rgba(80,100,250,0.13) 65%,rgba(255,255,255,0.03) 100%);
+  opacity: 1;
+  transition: left 0.33s;
+  pointer-events: none;
+}
+.button.checkout-mat:hover:after {
+  left: 110%;
+  transition: left 0.55s;
+}
+.button.checkout-mat:hover, .button.checkout-mat:focus {
+  background: #f4f7ff;
+  color: #3149cc;
+  border-color: #3149cc;
+  box-shadow: 0 6px 18px rgba(90,110,220,0.06);
+  transform: translateY(-2px) scale(1.017);
+}
+
+@media (max-width: 900px) {
+  .group-classes-hero__main { flex-direction: column; gap: 22px; }
+  .group-classes-hero__visual { flex-direction: row; gap: 1.5rem; justify-content: flex-start; }
+  .group-classes-hero__image, .group-classes-cart-box, .button.checkout-mat { max-width: 48vw; }
+  .group-classes-hero__content { max-width: 100%; padding: 1.5rem 0.5rem 1.2rem 0.5rem; }
+}
+@media (max-width: 600px) {
+  .group-classes-hero__visual { flex-direction: column; align-items: center; }
+  .group-classes-hero__image, .group-classes-cart-box, .button.checkout-mat { max-width: 100%; }
+  .group-classes-cart-box { padding: 1.3rem 0.8rem; }
+}
+</style>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const params = new URLSearchParams(window.location.search);
+  const price = params.get('price');
+  let plan = "Monthly";
+  if (params.get('plan')) {
+    plan = params.get('plan')
+      .replace('monthly','Monthly')
+      .replace('quarterly','3-Month')
+      .replace('yearly','12-Month');
+  } else if (price && price.includes('44')) {
+    plan = "3-Month";
+  } else if (price && price.includes('29')) {
+    plan = "12-Month";
+  }
+  document.getElementById('cartPrice').textContent = price ? price : '$49.99';
+  document.getElementById('cartPlanName').textContent = plan;
+  const checkoutBtn = document.getElementById('checkoutBtn');
+  let checkoutUrl = `/checkout?package=group-classes`;
+  if(price) checkoutUrl += `&price=${encodeURIComponent(price)}`;
+  if(plan) checkoutUrl += `&plan=${encodeURIComponent(plan)}`;
+  checkoutBtn.setAttribute('href', checkoutUrl);
+
+});
+</script>

--- a/theme/sections/header.liquid
+++ b/theme/sections/header.liquid
@@ -1,0 +1,700 @@
+<link rel="stylesheet" href="{{ 'component-list-menu.css' | asset_url }}" media="print" onload="this.media='all'">
+<link rel="stylesheet" href="{{ 'component-menu-drawer.css' | asset_url }}" media="print" onload="this.media='all'">
+<link
+  rel="stylesheet"
+  href="{{ 'component-cart-notification.css' | asset_url }}"
+  media="print"
+  onload="this.media='all'"
+>
+
+{%- if settings.predictive_search_enabled -%}
+  <link rel="stylesheet" href="{{ 'component-price.css' | asset_url }}" media="print" onload="this.media='all'">
+{%- endif -%}
+
+{%- if section.settings.menu_type_desktop == 'mega' -%}
+  <link rel="stylesheet" href="{{ 'component-mega-menu.css' | asset_url }}" media="print" onload="this.media='all'">
+{%- endif -%}
+
+<style>
+  header-drawer {
+    justify-self: start;
+    margin-left: -1.2rem;
+  }
+
+  {%- if section.settings.sticky_header_type == 'reduce-logo-size' -%}
+    .scrolled-past-header .header__heading-logo-wrapper {
+      width: 75%;
+    }
+  {%- endif -%}
+
+  {%- if section.settings.menu_type_desktop != "drawer" -%}
+    @media screen and (min-width: 990px) {
+      header-drawer {
+        display: none;
+      }
+    }
+  {%- endif -%}
+
+  .menu-drawer-container {
+    display: flex;
+  }
+
+  .list-menu {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .list-menu--inline {
+    display: inline-flex;
+    flex-wrap: wrap;
+  }
+
+  summary.list-menu__item {
+    padding-right: 2.7rem;
+  }
+
+  .list-menu__item {
+    display: flex;
+    align-items: center;
+    line-height: calc(1 + 0.3 / var(--font-body-scale));
+  }
+
+  .list-menu__item--link {
+    text-decoration: none;
+    padding-bottom: 1rem;
+    padding-top: 1rem;
+    line-height: calc(1 + 0.8 / var(--font-body-scale));
+  }
+
+  @media screen and (min-width: 750px) {
+    .list-menu__item--link {
+      padding-bottom: 0.5rem;
+      padding-top: 0.5rem;
+    }
+  }
+
+  /* Navigation layout tweaks */
+  .header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .main-navbar {
+    display: flex !important;
+    margin-left: auto;
+    gap: 2rem;
+  }
+
+  .main-navbar .header__menu-item {
+    position: relative;
+    padding: 0.7rem 1.3rem;
+  }
+
+  .main-navbar .header__menu-item:hover {
+    color: #2672ff;
+  }
+
+  .main-navbar .header__menu-item:hover::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 2px;
+    background: #2672ff;
+    animation: nav-flicker 0.6s linear;
+  }
+
+  /* Smooth scrolling for in-page anchors on the index page */
+  {%- if request.page_type == 'index' -%}
+    html {
+      scroll-behavior: smooth;
+    }
+  {%- endif -%}
+
+  @keyframes nav-flicker {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0; }
+  }
+
+  /* Hide menu links and icons on small screens so only the drawer shows */
+  @media screen and (max-width: 749px) {
+    .header__inline-menu,
+    .header__icons {
+      display: none !important;
+    }
+  }
+</style>
+
+{%- style -%}
+  .header {
+    padding: {{ section.settings.padding_top | times: 0.5 | round: 0 }}px 3rem {{ section.settings.padding_bottom | times: 0.5 | round: 0 }}px 3rem;
+  }
+
+  .section-header {
+    position: sticky; /* This is for fixing a Safari z-index issue. PR #2147 */
+    margin-bottom: {{ section.settings.margin_bottom | times: 0.75 | round: 0 }}px;
+  }
+
+  @media screen and (min-width: 750px) {
+    .section-header {
+      margin-bottom: {{ section.settings.margin_bottom }}px;
+    }
+  }
+
+  @media screen and (min-width: 990px) {
+    .header {
+      padding-top: {{ section.settings.padding_top }}px;
+      padding-bottom: {{ section.settings.padding_bottom }}px;
+    }
+  }
+{%- endstyle -%}
+
+<script src="{{ 'cart-notification.js' | asset_url }}" defer="defer"></script>
+
+{%- liquid
+  for block in section.blocks
+    if block.type == '@app'
+      assign has_app_block = true
+    endif
+  endfor
+-%}
+
+{% liquid
+  assign header_tag = 'div'
+
+  if section.settings.sticky_header_type != 'none'
+    assign header_tag = 'sticky-header'
+  endif
+%}
+
+<{{ header_tag }}
+  {% if header_tag == 'sticky-header' %}
+    data-sticky-type="{{ section.settings.sticky_header_type }}"
+  {% endif %}
+  class="header-wrapper color-{{ section.settings.color_scheme }} gradient{% if section.settings.show_line_separator %} header-wrapper--border-bottom{% endif %}"
+>
+  {%- liquid
+    assign social_links = false
+    assign localization_forms = false
+
+    if settings.social_twitter_link != blank or settings.social_facebook_link != blank or settings.social_pinterest_link != blank or settings.social_instagram_link != blank or settings.social_youtube_link != blank or settings.social_vimeo_link != blank or settings.social_tiktok_link != blank or settings.social_tumblr_link != blank or settings.social_snapchat_link != blank
+      assign social_links = true
+    endif
+
+    if localization.available_countries.size > 1 and section.settings.enable_country_selector or section.settings.enable_language_selector and localization.available_languages.size > 1
+      assign localization_forms = true
+    endif
+  -%}
+  <header class="header header--{{ section.settings.logo_position }} header--mobile-{{ section.settings.mobile_logo_position }} page-width{% if section.settings.menu_type_desktop == 'drawer' %} drawer-menu{% endif %}{% if section.settings.menu != blank %} header--has-menu{% endif %}{% if has_app_block %} header--has-app{% endif %}{% if social_links %} header--has-social{% endif %}{% if shop.customer_accounts_enabled %} header--has-account{% endif %}{% if localization_forms %} header--has-localizations{% endif %}">
+    {%- liquid
+      render 'header-drawer'
+    -%}
+
+    {%- if section.settings.logo_position != 'middle-center' -%}
+      {%- if request.page_type == 'index' -%}
+        <h1 class="header__heading">
+      {%- endif -%}
+      <a href="{{ routes.root_url }}" class="header__heading-link link link--text focus-inset">
+        {%- if settings.logo != blank -%}
+          <div class="header__heading-logo-wrapper">
+            {%- assign logo_alt = settings.logo.alt | default: shop.name | escape -%}
+            {%- assign logo_height = settings.logo_width | divided_by: settings.logo.aspect_ratio -%}
+            {% capture sizes %}(max-width: {{ settings.logo_width | times: 2 }}px) 50vw, {{ settings.logo_width }}px{% endcapture %}
+            {% capture widths %}{{ settings.logo_width }}, {{ settings.logo_width | times: 1.5 | round }}, {{ settings.logo_width | times: 2 }}{% endcapture %}
+            {{
+              settings.logo
+              | image_url: width: 600
+              | image_tag:
+                class: 'header__heading-logo motion-reduce',
+                widths: widths,
+                height: logo_height,
+                width: settings.logo_width,
+                alt: logo_alt,
+                sizes: sizes,
+                preload: true
+            }}
+          </div>
+        {%- else -%}
+          <span class="h2">{{ shop.name }}</span>
+        {%- endif -%}
+      </a>
+      {%- if request.page_type == 'index' -%}
+        </h1>
+      {%- endif -%}
+    {%- endif -%}
+
+    {%- liquid
+      if section.settings.menu_type_desktop == 'dropdown'
+        render 'header-dropdown-menu'
+      elsif section.settings.menu_type_desktop != 'drawer'
+        render 'header-mega-menu'
+      endif
+    %}
+
+    {%- if section.settings.logo_position == 'middle-center' -%}
+      {%- if request.page_type == 'index' -%}
+        <h1 class="header__heading">
+      {%- endif -%}
+      <a href="{{ routes.root_url }}" class="header__heading-link link link--text focus-inset">
+        {%- if settings.logo != blank -%}
+          <div class="header__heading-logo-wrapper">
+            {%- assign logo_alt = settings.logo.alt | default: shop.name | escape -%}
+            {%- assign logo_height = settings.logo_width | divided_by: settings.logo.aspect_ratio -%}
+            {% capture sizes %}(min-width: 750px) {{ settings.logo_width }}px, 50vw{% endcapture %}
+            {% capture widths %}{{ settings.logo_width }}, {{ settings.logo_width | times: 1.5 | round }}, {{ settings.logo_width | times: 2 }}{% endcapture %}
+            {{
+              settings.logo
+              | image_url: width: 600
+              | image_tag:
+                class: 'header__heading-logo',
+                widths: widths,
+                height: logo_height,
+                width: settings.logo_width,
+                alt: logo_alt,
+                sizes: sizes,
+                preload: true
+            }}
+          </div>
+        {%- else -%}
+          <span class="h2">{{ shop.name }}</span>
+        {%- endif -%}
+      </a>
+      {%- if request.page_type == 'index' -%}
+        </h1>
+      {%- endif -%}
+    {%- endif -%}
+
+    <div class="header__icons small-hide{% if section.settings.enable_country_selector or section.settings.enable_language_selector %} header__icons--localization header-localization{% endif %}">
+      <div class="desktop-localization-wrapper">
+        {%- if section.settings.enable_country_selector and localization.available_countries.size > 1 -%}
+          <localization-form class="small-hide medium-hide" data-prevent-hide>
+            {%- form 'localization', id: 'HeaderCountryForm', class: 'localization-form' -%}
+              <div>
+                <h2 class="visually-hidden" id="HeaderCountryLabel">{{ 'localization.country_label' | t }}</h2>
+                {%- render 'country-localization', localPosition: 'HeaderCountry' -%}
+              </div>
+            {%- endform -%}
+          </localization-form>
+        {% endif %}
+
+        {%- if section.settings.enable_language_selector and localization.available_languages.size > 1 -%}
+          <localization-form class="small-hide medium-hide" data-prevent-hide>
+            {%- form 'localization', id: 'HeaderLanguageForm', class: 'localization-form' -%}
+              <div>
+                <h2 class="visually-hidden" id="HeaderLanguageLabel">{{ 'localization.language_label' | t }}</h2>
+                {%- render 'language-localization', localPosition: 'HeaderLanguage' -%}
+              </div>
+            {%- endform -%}
+          </localization-form>
+        {%- endif -%}
+      </div>
+      {%- if shop.customer_accounts_enabled -%}
+        <a
+          href="{%- if customer -%}{{ routes.account_url }}{%- else -%}{{ routes.account_login_url }}{%- endif -%}"
+          class="header__icon header__icon--account link focus-inset{% if section.settings.menu != blank %} small-hide{% endif %}"
+          rel="nofollow"
+        >
+          {%- if section.settings.enable_customer_avatar -%}
+            <account-icon>
+              {%- if customer and customer.has_avatar? -%}
+                {{ customer | avatar }}
+              {%- else -%}
+                <span class="svg-wrapper">{{ 'icon-account.svg' | inline_asset_content }}</span>
+              {%- endif -%}
+            </account-icon>
+          {%- else -%}
+            <span class="svg-wrapper">{{ 'icon-account.svg' | inline_asset_content }}</span>
+          {%- endif -%}
+          <span class="visually-hidden">
+            {%- liquid
+              if customer
+                echo 'customer.account_fallback' | t
+              else
+                echo 'customer.log_in' | t
+              endif
+            -%}
+          </span>
+        </a>
+      {%- endif -%}
+
+      {%- for block in section.blocks -%}
+        {%- case block.type -%}
+          {%- when '@app' -%}
+            {% render block %}
+        {%- endcase -%}
+      {%- endfor -%}
+
+      <a href="{{ routes.cart_url }}" class="header__icon header__icon--cart link focus-inset" id="cart-icon-bubble">
+        {% if cart == empty %}
+          <span class="svg-wrapper">{{ 'icon-cart-empty.svg' | inline_asset_content }}</span>
+        {% else %}
+          <span class="svg-wrapper">{{ 'icon-cart.svg' | inline_asset_content }}</span>
+        {% endif %}
+        <span class="visually-hidden">{{ 'templates.cart.cart' | t }}</span>
+        {%- if cart != empty -%}
+          <div class="cart-count-bubble">
+            {%- if cart.item_count < 100 -%}
+              <span aria-hidden="true">{{ cart.item_count }}</span>
+            {%- endif -%}
+            <span class="visually-hidden">{{ 'sections.header.cart_count' | t: count: cart.item_count }}</span>
+          </div>
+        {%- endif -%}
+      </a>
+    </div>
+  </header>
+</{{ header_tag }}>
+
+{%- if settings.cart_type == 'notification' -%}
+  {%- render 'cart-notification',
+    color_scheme: section.settings.color_scheme,
+    desktop_menu_type: section.settings.menu_type_desktop
+  -%}
+{%- endif -%}
+
+{% javascript %}
+  class StickyHeader extends HTMLElement {
+    constructor() {
+      super();
+    }
+
+    connectedCallback() {
+      this.header = document.querySelector('.section-header');
+      this.headerIsAlwaysSticky =
+        this.getAttribute('data-sticky-type') === 'always' ||
+        this.getAttribute('data-sticky-type') === 'reduce-logo-size';
+      this.headerBounds = {};
+
+      this.setHeaderHeight();
+
+      window.matchMedia('(max-width: 990px)').addEventListener('change', this.setHeaderHeight.bind(this));
+
+      if (this.headerIsAlwaysSticky) {
+        this.header.classList.add('shopify-section-header-sticky');
+      }
+
+      this.currentScrollTop = 0;
+      this.preventReveal = false;
+      this.predictiveSearch = this.querySelector('predictive-search');
+
+      this.onScrollHandler = this.onScroll.bind(this);
+      this.hideHeaderOnScrollUp = () => (this.preventReveal = true);
+
+      this.addEventListener('preventHeaderReveal', this.hideHeaderOnScrollUp);
+      window.addEventListener('scroll', this.onScrollHandler, false);
+
+      this.createObserver();
+    }
+
+    setHeaderHeight() {
+      document.documentElement.style.setProperty('--header-height', `${this.header.offsetHeight}px`);
+    }
+
+    disconnectedCallback() {
+      this.removeEventListener('preventHeaderReveal', this.hideHeaderOnScrollUp);
+      window.removeEventListener('scroll', this.onScrollHandler);
+    }
+
+    createObserver() {
+      let observer = new IntersectionObserver((entries, observer) => {
+        this.headerBounds = entries[0].intersectionRect;
+        observer.disconnect();
+      });
+
+      observer.observe(this.header);
+    }
+
+    onScroll() {
+      const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+
+      if (this.predictiveSearch && this.predictiveSearch.isOpen) return;
+
+      if (scrollTop > this.currentScrollTop && scrollTop > this.headerBounds.bottom) {
+        this.header.classList.add('scrolled-past-header');
+        if (this.preventHide) return;
+        requestAnimationFrame(this.hide.bind(this));
+      } else if (scrollTop < this.currentScrollTop && scrollTop > this.headerBounds.bottom) {
+        this.header.classList.add('scrolled-past-header');
+        if (!this.preventReveal) {
+          requestAnimationFrame(this.reveal.bind(this));
+        } else {
+          window.clearTimeout(this.isScrolling);
+
+          this.isScrolling = setTimeout(() => {
+            this.preventReveal = false;
+          }, 66);
+
+          requestAnimationFrame(this.hide.bind(this));
+        }
+      } else if (scrollTop <= this.headerBounds.top) {
+        this.header.classList.remove('scrolled-past-header');
+        requestAnimationFrame(this.reset.bind(this));
+      }
+
+      this.currentScrollTop = scrollTop;
+    }
+
+    hide() {
+      if (this.headerIsAlwaysSticky) return;
+      this.header.classList.add('shopify-section-header-hidden', 'shopify-section-header-sticky');
+      this.closeMenuDisclosure();
+      this.closeSearchModal();
+    }
+
+    reveal() {
+      if (this.headerIsAlwaysSticky) return;
+      this.header.classList.add('shopify-section-header-sticky', 'animate');
+      this.header.classList.remove('shopify-section-header-hidden');
+    }
+
+    reset() {
+      if (this.headerIsAlwaysSticky) return;
+      this.header.classList.remove('shopify-section-header-hidden', 'shopify-section-header-sticky', 'animate');
+    }
+
+    closeMenuDisclosure() {
+      this.disclosures = this.disclosures || this.header.querySelectorAll('header-menu');
+      this.disclosures.forEach((disclosure) => disclosure.close());
+    }
+
+    closeSearchModal() {
+      this.searchModal = this.searchModal || this.header.querySelector('details-modal');
+      this.searchModal.close(false);
+    }
+  }
+
+  customElements.define('sticky-header', StickyHeader);
+{% endjavascript %}
+
+<script type="application/ld+json">
+  {
+    "@context": "http://schema.org",
+    "@type": "Organization",
+    "name": {{ shop.name | json }},
+    {% if settings.logo %}
+      "logo": {{ settings.logo | image_url: width: 500 | prepend: "https:" | json }},
+    {% endif %}
+    "sameAs": [
+      {{ settings.social_twitter_link | json }},
+      {{ settings.social_facebook_link | json }},
+      {{ settings.social_pinterest_link | json }},
+      {{ settings.social_instagram_link | json }},
+      {{ settings.social_tiktok_link | json }},
+      {{ settings.social_tumblr_link | json }},
+      {{ settings.social_snapchat_link | json }},
+      {{ settings.social_youtube_link | json }},
+      {{ settings.social_vimeo_link | json }}
+    ],
+    "url": {{ request.origin | append: page.url | json }}
+  }
+</script>
+
+{%- if request.page_type == 'index' -%}
+  {% assign potential_action_target = request.origin | append: routes.search_url | append: '?q={search_term_string}' %}
+  <script type="application/ld+json">
+    {
+      "@context": "http://schema.org",
+      "@type": "WebSite",
+      "name": {{ shop.name | json }},
+      "potentialAction": {
+        "@type": "SearchAction",
+        "target": {{ potential_action_target | json }},
+        "query-input": "required name=search_term_string"
+      },
+      "url": {{ request.origin | append: page.url | json }}
+    }
+  </script>
+{%- endif -%}
+
+{% schema %}
+{
+  "name": "t:sections.header.name",
+  "class": "section-header",
+  "max_blocks": 3,
+  "settings": [
+    {
+      "type": "select",
+      "id": "logo_position",
+      "options": [
+        {
+          "value": "top-left",
+          "label": "t:sections.header.settings.logo_position.options__2.label"
+        },
+        {
+          "value": "top-center",
+          "label": "t:sections.header.settings.logo_position.options__3.label"
+        },
+        {
+          "value": "middle-left",
+          "label": "t:sections.header.settings.logo_position.options__1.label"
+        },
+        {
+          "value": "middle-center",
+          "label": "t:sections.header.settings.logo_position.options__4.label"
+        }
+      ],
+      "default": "middle-left",
+      "label": "t:sections.header.settings.logo_position.label",
+      "info": "t:sections.header.settings.logo_help.content"
+    },
+    {
+      "type": "select",
+      "id": "mobile_logo_position",
+      "options": [
+        {
+          "value": "center",
+          "label": "t:sections.header.settings.mobile_logo_position.options__1.label"
+        },
+        {
+          "value": "left",
+          "label": "t:sections.header.settings.mobile_logo_position.options__2.label"
+        }
+      ],
+      "default": "center",
+      "label": "t:sections.header.settings.mobile_logo_position.label"
+    },
+    {
+      "type": "link_list",
+      "id": "menu",
+      "default": "main-menu",
+      "label": "t:sections.header.settings.menu.label"
+    },
+    {
+      "type": "select",
+      "id": "menu_type_desktop",
+      "options": [
+        {
+          "value": "dropdown",
+          "label": "t:sections.header.settings.menu_type_desktop.options__1.label"
+        },
+        {
+          "value": "mega",
+          "label": "t:sections.header.settings.menu_type_desktop.options__2.label"
+        },
+        {
+          "value": "drawer",
+          "label": "t:sections.header.settings.menu_type_desktop.options__3.label"
+        }
+      ],
+      "default": "dropdown",
+      "label": "t:sections.header.settings.menu_type_desktop.label"
+    },
+    {
+      "type": "select",
+      "id": "sticky_header_type",
+      "options": [
+        {
+          "value": "none",
+          "label": "t:sections.header.settings.sticky_header_type.options__1.label"
+        },
+        {
+          "value": "on-scroll-up",
+          "label": "t:sections.header.settings.sticky_header_type.options__2.label"
+        },
+        {
+          "value": "always",
+          "label": "t:sections.header.settings.sticky_header_type.options__3.label"
+        },
+        {
+          "value": "reduce-logo-size",
+          "label": "t:sections.header.settings.sticky_header_type.options__4.label"
+        }
+      ],
+      "default": "on-scroll-up",
+      "label": "t:sections.header.settings.sticky_header_type.label"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_line_separator",
+      "default": true,
+      "label": "t:sections.header.settings.show_line_separator.label"
+    },
+    {
+      "type": "header",
+      "content": "t:sections.header.settings.header__1.content"
+    },
+    {
+      "type": "color_scheme",
+      "id": "color_scheme",
+      "label": "t:sections.all.colors.label",
+      "default": "scheme-1"
+    },
+    {
+      "type": "color_scheme",
+      "id": "menu_color_scheme",
+      "label": "t:sections.header.settings.menu_color_scheme.label",
+      "default": "scheme-1"
+    },
+    {
+      "type": "header",
+      "content": "t:sections.header.settings.header__utilities.content"
+    },
+    {
+      "type": "checkbox",
+      "id": "enable_country_selector",
+      "default": true,
+      "label": "t:sections.header.settings.enable_country_selector.label",
+      "info": "t:sections.header.settings.enable_country_selector.info"
+    },
+    {
+      "type": "checkbox",
+      "id": "enable_language_selector",
+      "default": true,
+      "label": "t:sections.header.settings.enable_language_selector.label",
+      "info": "t:sections.header.settings.enable_language_selector.info"
+    },
+    {
+      "type": "checkbox",
+      "id": "enable_customer_avatar",
+      "default": true,
+      "label": "t:sections.header.settings.enable_customer_avatar.label",
+      "info": "t:sections.header.settings.enable_customer_avatar.info"
+    },
+    {
+      "type": "header",
+      "content": "t:sections.all.spacing"
+    },
+    {
+      "type": "range",
+      "id": "margin_bottom",
+      "min": 0,
+      "max": 100,
+      "step": 4,
+      "unit": "px",
+      "label": "t:sections.header.settings.margin_bottom.label",
+      "default": 0
+    },
+    {
+      "type": "header",
+      "content": "t:sections.all.padding.section_padding_heading"
+    },
+    {
+      "type": "range",
+      "id": "padding_top",
+      "min": 0,
+      "max": 36,
+      "step": 4,
+      "unit": "px",
+      "label": "t:sections.all.padding.padding_top",
+      "default": 20
+    },
+    {
+      "type": "range",
+      "id": "padding_bottom",
+      "min": 0,
+      "max": 36,
+      "step": 4,
+      "unit": "px",
+      "label": "t:sections.all.padding.padding_bottom",
+      "default": 20
+    }
+  ],
+  "blocks": [
+    {
+      "type": "@app"
+    }
+  ]
+}
+{% endschema %}

--- a/theme/sections/private-tutoring.liquid
+++ b/theme/sections/private-tutoring.liquid
@@ -1,0 +1,271 @@
+<section class="private-tutoring-hero-bg">
+  <div class="private-tutoring-hero page-width">
+    <div class="private-tutoring-hero__main">
+      <!-- SOL: Bilgi -->
+      <div class="private-tutoring-hero__content">
+        <h1>Private Tutoring</h1>
+        <p>
+          Unlock your English with <b>1-on-1 private sessions</b> tailored for you.<br>
+          Flexible scheduling, expert tutors, and measurable progress — all in one place.
+        </p>
+        <ul class="features">
+          <li>Personalized lesson plans</li>
+          <li>Native, certified tutors</li>
+          <li>60-minute live sessions</li>
+          <li>Flexible times, any day</li>
+          <li>All digital materials included</li>
+          <li>Weekly progress reports</li>
+        </ul>
+        <div class="info-note">
+          <small>Questions? <a href="/contact">Contact us</a> for custom plans!</small>
+        </div>
+      </div>
+      <!-- SAĞ: Görsel + Checkout Cart + Dışarıda Buton -->
+      <div class="private-tutoring-hero__visual">
+        <img class="private-tutoring-hero__image" src="https://cdn.shopify.com/s/files/1/0759/1546/0848/files/ChatGPT_Image_7_Tem_2025_15_58_34.png?v=1751893408" alt="Online English Tutoring, AI generated" loading="lazy" />
+        <div class="private-tutoring-cart-box">
+          <div class="cart-title">Your Selection</div>
+          <div class="cart-package"><strong>Private Tutoring</strong></div>
+          <div class="cart-plan">Plan: <span id="cartPlanName">Monthly</span></div>
+          <div class="cart-price" id="cartPrice">$199.99</div>
+          <ul class="cart-benefits">
+            <li>1 student</li>
+            <li>1-on-1 lessons</li>
+            <li>Flexible schedule</li>
+            <li>All resources included</li>
+          </ul>
+          <div class="cart-note">
+            <small>* All prices include VAT. Each session is 60 minutes.</small>
+          </div>
+        </div>
+        <!-- Buton KUTUNUN DIŞINDA ve köşeli -->
+        <a id="checkoutBtn" href="/checkout" class="button checkout-mat">Proceed to Checkout</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+<style>
+body {
+  background: linear-gradient(120deg, #f7faff 0%, #edf1fc 42%, #e6eafb 100%) !important;
+}
+.private-tutoring-hero-bg {
+  background: linear-gradient(105deg, #ffffff 60%, #e7e9fb 100%);
+  min-height: 80vh;
+  padding-top: 40px;
+  padding-bottom: 0;
+}
+.private-tutoring-hero {
+  max-width: 1160px;
+  margin: 0 auto;
+  padding: 0 12px;
+}
+.private-tutoring-hero__main {
+  display: flex;
+  gap: 40px;
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+.private-tutoring-hero__content {
+  flex: 2 1 430px;
+  min-width: 320px;
+  max-width: 600px;
+  padding: 2.3rem 1.3rem 2.1rem 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  background: none;
+}
+.private-tutoring-hero__content h1 {
+  font-size: 2.3rem;
+  font-weight: 800;
+  color: #21264b;
+  margin-bottom: 0.8rem;
+}
+.private-tutoring-hero__content p {
+  font-size: 1.18rem;
+  color: #31315b;
+  margin-bottom: 1.3rem;
+}
+.features {
+  list-style: none;
+  padding: 0;
+  margin: 1.1rem 0 1.1rem 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem 1.7rem;
+}
+.features li {
+  position: relative;
+  padding-left: 1.23rem;
+  font-size: 1.05rem;
+  color: #28305e;
+  flex: 0 0 220px;
+  margin-bottom: 0.2rem;
+}
+.features li:before {
+  content: "✔";
+  position: absolute;
+  left: 0;
+  color: #4e54c8;
+  font-weight: bold;
+  font-size: 1rem;
+}
+.info-note {
+  margin-top: 0.6rem;
+  color: #4e54c8;
+  font-size: 0.96rem;
+}
+
+/* --- VISUAL SIDE --- */
+.private-tutoring-hero__visual {
+  flex: 1 1 380px;
+  min-width: 290px;
+  max-width: 420px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2.1rem;
+}
+.private-tutoring-hero__image {
+  width: 100%;
+  max-width: 340px;
+  object-fit: cover;
+  background: #f8fafc;
+  margin-bottom: 0.5rem;
+  /* Köşeli ve gölgesiz! */
+  border-radius: 0 !important;
+  box-shadow: none !important;
+}
+.private-tutoring-cart-box {
+  width: 100%;
+  max-width: 340px;
+  padding: 2rem 1.6rem 1.5rem 1.6rem;
+  background: #fff;
+  box-shadow: none;
+  border-radius: 0 !important;
+  border: 1.5px solid #e4e7f0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  margin-top: 0;
+  margin-bottom: 1.15rem;
+}
+.cart-title {
+  font-size: 1.12rem;
+  font-weight: 700;
+  color: #4e54c8;
+  margin-bottom: 0.7rem;
+}
+.cart-package { font-size: 1.09rem; font-weight: 600; color: #23235b; margin-bottom: 0.3rem; }
+.cart-plan { margin-bottom: 0.3rem; font-size: 1.01rem; color: #28305e; }
+.cart-price {
+  font-size: 1.28rem;
+  font-weight: 800;
+  color: #4e54c8;
+  margin-bottom: 1rem;
+  background: none;
+  -webkit-background-clip: initial;
+  -webkit-text-fill-color: initial;
+}
+.cart-benefits {
+  list-style: none;
+  margin: 0 0 0.7rem 0;
+  padding: 0;
+  font-size: 0.98rem;
+}
+.cart-benefits li {
+  position: relative;
+  padding-left: 1.2rem;
+  margin-bottom: 0.3rem;
+  color: #444;
+}
+.cart-benefits li:before { content: "–"; position: absolute; left: 0; color: #8f94fb;}
+.cart-note { font-size: 0.93rem; color: #555; margin-top: 0.1rem;}
+.cart-note a { color: #4e54c8; }
+
+/* --- BUTON TAM KÖŞELİ, BEYAZ, FLICKER EFFECT --- */
+.button.checkout-mat {
+  margin-top: 16px;
+  display: block;
+  width: 100%;
+  max-width: 340px;
+  height: 56px;
+  line-height: 56px;
+  text-align: center;
+  font-size: 1.13rem;
+  font-weight: 700;
+  background: #fff;
+  color: #4e54c8;
+  border: 2px solid #4e54c8;
+  border-radius: 0;
+  box-shadow: none;
+  cursor: pointer;
+  letter-spacing: 0.01em;
+  outline: none;
+  position: relative;
+  overflow: hidden;
+  transition: color 0.18s, border-color 0.22s, background 0.20s;
+}
+.button.checkout-mat:after {
+  content: "";
+  position: absolute;
+  top: 0; left: -60px;
+  width: 45px; height: 100%;
+  background: linear-gradient(100deg,rgba(76,107,255,0.12) 0%,rgba(80,100,250,0.13) 65%,rgba(255,255,255,0.03) 100%);
+  opacity: 1;
+  transition: left 0.33s;
+  pointer-events: none;
+}
+.button.checkout-mat:hover:after {
+  left: 110%;
+  transition: left 0.55s;
+}
+.button.checkout-mat:hover, .button.checkout-mat:focus {
+  background: #f4f7ff;
+  color: #3149cc;
+  border-color: #3149cc;
+  box-shadow: 0 6px 18px rgba(90,110,220,0.06);
+  transform: translateY(-2px) scale(1.017);
+}
+
+@media (max-width: 900px) {
+  .private-tutoring-hero__main { flex-direction: column; gap: 22px; }
+  .private-tutoring-hero__visual { flex-direction: row; gap: 1.5rem; justify-content: flex-start; }
+  .private-tutoring-hero__image, .private-tutoring-cart-box, .button.checkout-mat { max-width: 48vw; }
+  .private-tutoring-hero__content { max-width: 100%; padding: 1.5rem 0.5rem 1.2rem 0.5rem; }
+}
+@media (max-width: 600px) {
+  .private-tutoring-hero__visual { flex-direction: column; align-items: center; }
+  .private-tutoring-hero__image, .private-tutoring-cart-box, .button.checkout-mat { max-width: 100%; }
+  .private-tutoring-cart-box { padding: 1.3rem 0.8rem; }
+}
+</style>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const params = new URLSearchParams(window.location.search);
+  const price = params.get('price');
+  let plan = "Monthly";
+  if (params.get('plan')) {
+    plan = params.get('plan')
+      .replace('monthly','Monthly')
+      .replace('quarterly','3-Month')
+      .replace('yearly','12-Month');
+  } else if (price && price.includes('179')) {
+    plan = "3-Month";
+  } else if (price && price.includes('119')) {
+    plan = "12-Month";
+  }
+  document.getElementById('cartPrice').textContent = price ? price : '$199.99';
+  document.getElementById('cartPlanName').textContent = plan;
+  const checkoutBtn = document.getElementById('checkoutBtn');
+  let checkoutUrl = `/checkout?package=private-tutoring`;
+  if(price) checkoutUrl += `&price=${encodeURIComponent(price)}`;
+  if(plan) checkoutUrl += `&plan=${encodeURIComponent(plan)}`;
+  checkoutBtn.setAttribute('href', checkoutUrl);
+
+});
+</script>

--- a/theme/sections/small-group.liquid
+++ b/theme/sections/small-group.liquid
@@ -1,0 +1,270 @@
+<section class="small-group-hero-bg">
+  <div class="small-group-hero page-width">
+    <div class="small-group-hero__main">
+      <!-- SOL: Bilgi -->
+      <div class="small-group-hero__content">
+        <h1>Small Group</h1>
+        <p>
+          Learn together in a small setting of up to five learners.<br>          Experienced tutors keep you on track with engaging lessons.
+        </p>
+        <ul class="features">
+          <li>Small class size (max 5)</li>
+          <li>Focused attention</li>
+          <li>60-minute live sessions</li>
+          <li>Interactive activities</li>
+          <li>Digital materials included</li>
+          <li>Monthly progress reports</li>
+        </ul>
+        <div class="info-note">
+          <small>Questions? <a href="/contact">Contact us</a> for custom plans!</small>
+        </div>
+      </div>
+      <!-- SAĞ: Görsel + Checkout Cart + Dışarıda Buton -->
+      <div class="small-group-hero__visual">
+        <img class="small-group-hero__image" src="https://cdn.shopify.com/s/files/1/0759/1546/0848/files/ChatGPT_Image_7_Tem_2025_15_58_34.png?v=1751893408" alt="Online English Tutoring, AI generated" loading="lazy" />
+        <div class="small-group-cart-box">
+          <div class="cart-title">Your Selection</div>
+          <div class="cart-package"><strong>Small Group</strong></div>
+          <div class="cart-plan">Plan: <span id="cartPlanName">Monthly</span></div>
+          <div class="cart-price" id="cartPrice">$79.99</div>
+          <ul class="cart-benefits">
+            <li>Up to 5 students</li>
+            <li>Group collaboration</li>
+            <li>Set schedule</li>
+            <li>Materials included</li>
+          </ul>
+          <div class="cart-note">
+            <small>* All prices include VAT. Each session is 60 minutes.</small>
+          </div>
+        </div>
+        <!-- Buton KUTUNUN DIŞINDA ve köşeli -->
+        <a id="checkoutBtn" href="/checkout" class="button checkout-mat">Proceed to Checkout</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+<style>
+body {
+  background: linear-gradient(120deg, #f7faff 0%, #edf1fc 42%, #e6eafb 100%) !important;
+}
+.small-group-hero-bg {
+  background: linear-gradient(105deg, #ffffff 60%, #e7e9fb 100%);
+  min-height: 80vh;
+  padding-top: 40px;
+  padding-bottom: 0;
+}
+.small-group-hero {
+  max-width: 1160px;
+  margin: 0 auto;
+  padding: 0 12px;
+}
+.small-group-hero__main {
+  display: flex;
+  gap: 40px;
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+.small-group-hero__content {
+  flex: 2 1 430px;
+  min-width: 320px;
+  max-width: 600px;
+  padding: 2.3rem 1.3rem 2.1rem 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  background: none;
+}
+.small-group-hero__content h1 {
+  font-size: 2.3rem;
+  font-weight: 800;
+  color: #21264b;
+  margin-bottom: 0.8rem;
+}
+.small-group-hero__content p {
+  font-size: 1.18rem;
+  color: #31315b;
+  margin-bottom: 1.3rem;
+}
+.features {
+  list-style: none;
+  padding: 0;
+  margin: 1.1rem 0 1.1rem 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem 1.7rem;
+}
+.features li {
+  position: relative;
+  padding-left: 1.23rem;
+  font-size: 1.05rem;
+  color: #28305e;
+  flex: 0 0 220px;
+  margin-bottom: 0.2rem;
+}
+.features li:before {
+  content: "✔";
+  position: absolute;
+  left: 0;
+  color: #4e54c8;
+  font-weight: bold;
+  font-size: 1rem;
+}
+.info-note {
+  margin-top: 0.6rem;
+  color: #4e54c8;
+  font-size: 0.96rem;
+}
+
+/* --- VISUAL SIDE --- */
+.small-group-hero__visual {
+  flex: 1 1 380px;
+  min-width: 290px;
+  max-width: 420px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2.1rem;
+}
+.small-group-hero__image {
+  width: 100%;
+  max-width: 340px;
+  object-fit: cover;
+  background: #f8fafc;
+  margin-bottom: 0.5rem;
+  /* Köşeli ve gölgesiz! */
+  border-radius: 0 !important;
+  box-shadow: none !important;
+}
+.small-group-cart-box {
+  width: 100%;
+  max-width: 340px;
+  padding: 2rem 1.6rem 1.5rem 1.6rem;
+  background: #fff;
+  box-shadow: none;
+  border-radius: 0 !important;
+  border: 1.5px solid #e4e7f0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  margin-top: 0;
+  margin-bottom: 1.15rem;
+}
+.cart-title {
+  font-size: 1.12rem;
+  font-weight: 700;
+  color: #4e54c8;
+  margin-bottom: 0.7rem;
+}
+.cart-package { font-size: 1.09rem; font-weight: 600; color: #23235b; margin-bottom: 0.3rem; }
+.cart-plan { margin-bottom: 0.3rem; font-size: 1.01rem; color: #28305e; }
+.cart-price {
+  font-size: 1.28rem;
+  font-weight: 800;
+  color: #4e54c8;
+  margin-bottom: 1rem;
+  background: none;
+  -webkit-background-clip: initial;
+  -webkit-text-fill-color: initial;
+}
+.cart-benefits {
+  list-style: none;
+  margin: 0 0 0.7rem 0;
+  padding: 0;
+  font-size: 0.98rem;
+}
+.cart-benefits li {
+  position: relative;
+  padding-left: 1.2rem;
+  margin-bottom: 0.3rem;
+  color: #444;
+}
+.cart-benefits li:before { content: "–"; position: absolute; left: 0; color: #8f94fb;}
+.cart-note { font-size: 0.93rem; color: #555; margin-top: 0.1rem;}
+.cart-note a { color: #4e54c8; }
+
+/* --- BUTON TAM KÖŞELİ, BEYAZ, FLICKER EFFECT --- */
+.button.checkout-mat {
+  margin-top: 16px;
+  display: block;
+  width: 100%;
+  max-width: 340px;
+  height: 56px;
+  line-height: 56px;
+  text-align: center;
+  font-size: 1.13rem;
+  font-weight: 700;
+  background: #fff;
+  color: #4e54c8;
+  border: 2px solid #4e54c8;
+  border-radius: 0;
+  box-shadow: none;
+  cursor: pointer;
+  letter-spacing: 0.01em;
+  outline: none;
+  position: relative;
+  overflow: hidden;
+  transition: color 0.18s, border-color 0.22s, background 0.20s;
+}
+.button.checkout-mat:after {
+  content: "";
+  position: absolute;
+  top: 0; left: -60px;
+  width: 45px; height: 100%;
+  background: linear-gradient(100deg,rgba(76,107,255,0.12) 0%,rgba(80,100,250,0.13) 65%,rgba(255,255,255,0.03) 100%);
+  opacity: 1;
+  transition: left 0.33s;
+  pointer-events: none;
+}
+.button.checkout-mat:hover:after {
+  left: 110%;
+  transition: left 0.55s;
+}
+.button.checkout-mat:hover, .button.checkout-mat:focus {
+  background: #f4f7ff;
+  color: #3149cc;
+  border-color: #3149cc;
+  box-shadow: 0 6px 18px rgba(90,110,220,0.06);
+  transform: translateY(-2px) scale(1.017);
+}
+
+@media (max-width: 900px) {
+  .small-group-hero__main { flex-direction: column; gap: 22px; }
+  .small-group-hero__visual { flex-direction: row; gap: 1.5rem; justify-content: flex-start; }
+  .small-group-hero__image, .small-group-cart-box, .button.checkout-mat { max-width: 48vw; }
+  .small-group-hero__content { max-width: 100%; padding: 1.5rem 0.5rem 1.2rem 0.5rem; }
+}
+@media (max-width: 600px) {
+  .small-group-hero__visual { flex-direction: column; align-items: center; }
+  .small-group-hero__image, .small-group-cart-box, .button.checkout-mat { max-width: 100%; }
+  .small-group-cart-box { padding: 1.3rem 0.8rem; }
+}
+</style>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const params = new URLSearchParams(window.location.search);
+  const price = params.get('price');
+  let plan = "Monthly";
+  if (params.get('plan')) {
+    plan = params.get('plan')
+      .replace('monthly','Monthly')
+      .replace('quarterly','3-Month')
+      .replace('yearly','12-Month');
+  } else if (price && price.includes('69')) {
+    plan = "3-Month";
+  } else if (price && price.includes('49')) {
+    plan = "12-Month";
+  }
+  document.getElementById('cartPrice').textContent = price ? price : '$79.99';
+  document.getElementById('cartPlanName').textContent = plan;
+  const checkoutBtn = document.getElementById('checkoutBtn');
+  let checkoutUrl = `/checkout?package=small-group`;
+  if(price) checkoutUrl += `&price=${encodeURIComponent(price)}`;
+  if(plan) checkoutUrl += `&plan=${encodeURIComponent(plan)}`;
+  checkoutBtn.setAttribute('href', checkoutUrl);
+
+});
+</script>

--- a/theme/sections/teacher-matching.liquid
+++ b/theme/sections/teacher-matching.liquid
@@ -1,0 +1,470 @@
+{% schema %}
+{
+  "name": "Teacher Matching",
+  "settings": [
+    {
+      "type": "text",
+      "id": "title",
+      "label": "Heading",
+      "default": "Choose Your Learning Plan"
+    },
+    {
+      "type": "richtext",
+      "id": "description",
+      "label": "Description",
+      "default": "<p>Select the package that fits your learning goals and budget</p>"
+    }
+  ],
+  "blocks": [
+    {
+      "type": "package",
+      "name": "Class Package",
+      "settings": [
+        {
+          "type": "text",
+          "id": "package_name",
+          "label": "Package Name"
+        },
+        {
+          "type": "text",
+          "id": "class_type",
+          "label": "Class Type",
+          "info": "e.g., 1-on-1, Small Group, Group Class"
+        },
+        {
+          "type": "text",
+          "id": "student_count",
+          "label": "Student Count",
+          "default": "1"
+        },
+        {
+          "type": "text",
+          "id": "monthly_price",
+          "label": "1-Month Price",
+          "default": "199.99"
+        },
+        {
+          "type": "text",
+          "id": "quarterly_price",
+          "label": "3-Month Price",
+          "default": "179.99",
+          "info": "Monthly rate for 3-month commitment"
+        },
+        {
+          "type": "text",
+          "id": "yearly_price",
+          "label": "12-Month Price",
+          "default": "119.99",
+          "info": "Monthly rate for 12-month commitment"
+        },
+        {
+          "type": "richtext",
+          "id": "features",
+          "label": "Features",
+          "default": "<p>Feature list</p>"
+        },
+        {
+          "type": "url",
+          "id": "booking_link",
+          "label": "Booking Link"
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "name": "Class Packages"
+    }
+  ]
+}
+{% endschema %}
+
+<div id="pricing" class="class-packages-section page-width">
+  <h1 class="h2">{{ section.settings.title }}</h1>
+  <div class="rte">{{ section.settings.description }}</div>
+  
+  <!-- Duration Toggle -->
+  <div class="duration-toggle">
+    <button class="duration-option active" data-duration="monthly">Monthly Plan</button>
+    <button class="duration-option" data-duration="quarterly">3-Month Plan (Save 7.5%)</button>
+    <button class="duration-option" data-duration="yearly">12-Month Plan (Save 40%)</button>
+  </div>
+  
+  <div class="package-grid">
+    <!-- 1-on-1 Package -->
+    <div class="package-card">
+      <div class="package-header">
+        <h3>Private Tutoring</h3>
+        <div class="class-type">1-on-1</div>
+      </div>
+      <div class="package-details">
+        <div class="student-count">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+            <circle cx="9" cy="7" r="4"></circle>
+          </svg>
+          1 student
+        </div>
+        <div class="price-display">
+          <div class="price-option monthly active">
+            <span class="price-amount">$199.99</span>
+            <span class="price-period">per month</span>
+          </div>
+          <div class="price-option quarterly">
+            <span class="price-amount">$179.99</span>
+            <span class="price-period">per month (3-month commitment)</span>
+            <div class="savings-badge">Save 7.5%</div>
+          </div>
+          <div class="price-option yearly">
+            <span class="price-amount">$119.99</span>
+            <span class="price-period">per month (12-month commitment)</span>
+            <div class="savings-badge">Save 40%</div>
+          </div>
+        </div>
+        <div class="package-features">
+          <ul>
+            <li>Personalized 60-minute lessons</li>
+            <li>Flexible scheduling</li>
+            <li>Custom curriculum</li>
+            <li>Weekly progress reports</li>
+          </ul>
+        </div>
+        <a href="/pages/private-tutoring" class="button button--primary book-now">Book Now</a>
+      </div>
+    </div>
+
+    <!-- Small Group Package -->
+    <div class="package-card">
+      <div class="package-header">
+        <h3>Small Group</h3>
+        <div class="class-type">5 students</div>
+      </div>
+      <div class="package-details">
+        <div class="student-count">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+            <circle cx="9" cy="7" r="4"></circle>
+            <path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
+            <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
+          </svg>
+          5 students
+        </div>
+        <div class="price-display">
+          <div class="price-option monthly active">
+            <span class="price-amount">$79.99</span>
+            <span class="price-period">per month</span>
+          </div>
+          <div class="price-option quarterly">
+            <span class="price-amount">$69.99</span>
+            <span class="price-period">per month (3-month commitment)</span>
+            <div class="savings-badge">Save 12.5%</div>
+          </div>
+          <div class="price-option yearly">
+            <span class="price-amount">$49.99</span>
+            <span class="price-period">per month (12-month commitment)</span>
+            <div class="savings-badge">Save 38%</div>
+          </div>
+        </div>
+        <div class="package-features">
+          <ul>
+            <li>60-minute group sessions</li>
+            <li>Max 5 students per class</li>
+            <li>Interactive activities</li>
+            <li>Monthly progress reports</li>
+          </ul>
+        </div>
+        <a href="/pages/small-group" class="button button--primary book-now">Book Now</a>
+      </div>
+    </div>
+
+    <!-- Group Class Package -->
+    <div class="package-card">
+      <div class="package-header">
+        <h3>Group Class</h3>
+        <div class="class-type">10 students</div>
+      </div>
+      <div class="package-details">
+        <div class="student-count">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+            <circle cx="9" cy="7" r="4"></circle>
+            <path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
+            <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
+          </svg>
+          10 students
+        </div>
+        <div class="price-display">
+          <div class="price-option monthly active">
+            <span class="price-amount">$49.99</span>
+            <span class="price-period">per month</span>
+          </div>
+          <div class="price-option quarterly">
+            <span class="price-amount">$44.99</span>
+            <span class="price-period">per month (3-month commitment)</span>
+            <div class="savings-badge">Save 10%</div>
+          </div>
+          <div class="price-option yearly">
+            <span class="price-amount">$29.99</span>
+            <span class="price-period">per month (12-month commitment)</span>
+            <div class="savings-badge">Save 40%</div>
+          </div>
+        </div>
+        <div class="package-features">
+          <ul>
+            <li>60-minute live classes</li>
+            <li>Max 10 students</li>
+            <li>Structured curriculum</li>
+            <li>Customized assessments</li>
+          </ul>
+        </div>
+        <a href="/pages/group-classes" class="button button--primary book-now">Book Now</a>
+      </div>
+    </div>
+  </div>
+</div>
+
+<style>
+ /* Main Section Styling */
+.class-packages-section {
+  text-align: center;
+  padding: 80px 20px;
+  background-color: #f9fafb;
+}
+
+/* Duration Toggle */
+.duration-toggle {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  margin: 30px auto;
+  max-width: 800px;
+  flex-wrap: wrap;
+}
+
+.duration-option {
+  padding: 14px 24px;
+  border: 2px solid #e0e7ff;
+  background: #ffffff;
+  border-radius: 8px;
+  font-weight: 600;
+  color: #4e54c8;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  white-space: nowrap;
+}
+
+.duration-option.active {
+  background: #4e54c8;
+  color: #ffffff;
+  border-color: #4e54c8;
+  box-shadow: 0 4px 8px rgba(78, 84, 200, 0.2);
+}
+
+/* Price Display */
+.price-display {
+  position: relative;
+  margin: 20px auto;
+  min-height: 90px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  transition: opacity 0.3s ease;
+}
+
+.price-option {
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  width: 100%;
+  opacity: 0;
+  transform: translateY(10px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.price-option.active {
+  display: flex;
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.price-amount {
+  font-size: 2.2rem;
+  font-weight: 700;
+  color: #1e293b;
+  margin-bottom: 5px;
+}
+
+.price-period {
+  font-size: 1rem;
+  color: #64748b;
+}
+
+.savings-badge {
+  position: absolute;
+  top: -10px;
+  right: 0;
+  background: #10b981;
+  color: #ffffff;
+  padding: 4px 12px;
+  border-radius: 20px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+/* Package Grid */
+.package-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 30px;
+  margin: 40px auto;
+  max-width: 1200px;
+}
+
+/* Package Card */
+.package-card {
+  padding: 30px;
+  border-radius: 16px;
+  box-shadow: 0 5px 25px rgba(78, 84, 200, 0.08);
+  background: #ffffff;
+  border: none;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  text-align: left;
+}
+
+.package-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 15px 30px rgba(78, 84, 200, 0.15);
+}
+
+.package-header {
+  text-align: center;
+}
+
+.package-header h3 {
+  font-size: 1.5rem;
+  color: #1e293b;
+  margin-bottom: 0.5rem;
+}
+
+.class-type {
+  display: inline-block;
+  padding: 6px 12px;
+  background: #e0e7ff;
+  color: #4e54c8;
+  border-radius: 20px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  margin-bottom: 1.5rem;
+}
+
+/* Student Count */
+.student-count {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #64748b;
+  margin: 1rem 0;
+}
+
+.student-count svg {
+  width: 18px;
+  height: 18px;
+  color: #4e54c8;
+}
+
+/* Features List */
+.package-features ul {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0;
+}
+
+.package-features li {
+  position: relative;
+  padding-left: 25px;
+  margin-bottom: 0.8rem;
+  color: #475569;
+}
+
+.package-features li:before {
+  content: "✓";
+  position: absolute;
+  left: 0;
+  color: #4e54c8;
+  font-weight: bold;
+}
+
+/* Button Styling */
+.button--primary {
+  background: linear-gradient(90deg, #4e54c8, #8f94fb);
+  color: #ffffff !important;
+  padding: 14px 28px;
+  border-radius: 8px;
+  margin-top: 20px;
+  display: inline-block;
+  width: 100%;
+  font-weight: 500;
+  text-decoration: none;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  border: none;
+  cursor: pointer;
+  text-align: center;
+}
+
+.button--primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 5px 15px rgba(78, 84, 200, 0.3);
+}
+
+/* Responsive Adjustments */
+@media (max-width: 767px) {
+  .duration-toggle {
+    flex-direction: column;
+    align-items: center;
+  }
+  
+  .duration-option {
+    width: 100%;
+    max-width: 250px;
+  }
+}
+</style>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const durationOptions = document.querySelectorAll('.duration-option');
+  
+  durationOptions.forEach(option => {
+    option.addEventListener('click', function() {
+      // Update toggle buttons
+      durationOptions.forEach(btn => btn.classList.remove('active'));
+      this.classList.add('active');
+      
+      const duration = this.dataset.duration;
+      
+      // Update price displays
+      document.querySelectorAll('.price-option').forEach(priceOption => {
+        priceOption.classList.remove('active');
+      });
+      
+      document.querySelectorAll(`.price-option.${duration}`).forEach(priceOption => {
+        priceOption.classList.add('active');
+      });
+    });
+  });
+
+  document.querySelectorAll('.package-card').forEach(card => {
+    const btn = card.querySelector('.book-now');
+    if (!btn) return;
+    btn.addEventListener('click', function(e) {
+      e.preventDefault();
+      const priceEl = card.querySelector('.price-option.active .price-amount');
+      const price = priceEl ? priceEl.textContent.trim() : '';
+      const target = btn.getAttribute('href');
+      window.location.href = `${target}?price=${encodeURIComponent(price)}`;
+    });
+  });
+});
+</script>

--- a/theme/snippets/header-drawer.liquid
+++ b/theme/snippets/header-drawer.liquid
@@ -1,0 +1,279 @@
+{% comment %}
+  Renders a header drawer menu for mobile and desktop.
+
+  Usage:
+  {% render 'header-drawer' %}
+{% endcomment %}
+
+<header-drawer data-breakpoint="{% if section.settings.menu_type_desktop == 'drawer' %}desktop{% else %}tablet{% endif %}">
+  <details id="Details-menu-drawer-container" class="menu-drawer-container">
+    <summary
+      class="header__icon header__icon--menu header__icon--summary link focus-inset"
+      aria-label="{{ 'sections.header.menu' | t }}"
+    >
+      <span>
+        {{- 'icon-hamburger.svg' | inline_asset_content -}}
+        {{- 'icon-close.svg' | inline_asset_content -}}
+      </span>
+    </summary>
+    <div id="menu-drawer" class="gradient menu-drawer motion-reduce color-{{ section.settings.menu_color_scheme }}">
+      <div class="menu-drawer__inner-container">
+        <div class="menu-drawer__navigation-container">
+          <nav class="menu-drawer__navigation">
+            <ul class="menu-drawer__menu has-submenu list-menu" role="list">
+              {%- for link in section.settings.menu.links -%}
+                <li>
+                  {%- if link.links != blank -%}
+                    <details id="Details-menu-drawer-menu-item-{{ forloop.index }}">
+                      <summary
+                        id="HeaderDrawer-{{ link.handle }}"
+                        class="menu-drawer__menu-item list-menu__item link link--text focus-inset{% if link.child_active %} menu-drawer__menu-item--active{% endif %}"
+                      >
+                        {{ link.title | escape }}
+                        <span class="svg-wrapper">
+                          {{- 'icon-arrow.svg' | inline_asset_content -}}
+                        </span>
+                        <span class="svg-wrapper">
+                          {{- 'icon-caret.svg' | inline_asset_content -}}
+                        </span>
+                      </summary>
+                      <div
+                        id="link-{{ link.handle | escape }}"
+                        class="menu-drawer__submenu has-submenu gradient motion-reduce"
+                        tabindex="-1"
+                      >
+                        <div class="menu-drawer__inner-submenu">
+                          <button class="menu-drawer__close-button link link--text focus-inset" aria-expanded="true">
+                            <span class="svg-wrapper">
+                              {{- 'icon-arrow.svg' | inline_asset_content -}}
+                            </span>
+                            {{ link.title | escape }}
+                          </button>
+                          <ul class="menu-drawer__menu list-menu" role="list" tabindex="-1">
+                            {%- for childlink in link.links -%}
+                              <li>
+                                {%- if childlink.links == blank -%}
+                                  <a
+                                    id="HeaderDrawer-{{ link.handle }}-{{ childlink.handle }}"
+                                    href="{{ childlink.url }}"
+                                    class="menu-drawer__menu-item link link--text list-menu__item focus-inset{% if childlink.current %} menu-drawer__menu-item--active{% endif %}"
+                                    {% if childlink.current %}
+                                      aria-current="page"
+                                    {% endif %}
+                                  >
+                                    {{ childlink.title | escape }}
+                                  </a>
+                                {%- else -%}
+                                  <details id="Details-menu-drawer-{{ link.handle }}-{{ childlink.handle }}">
+                                    <summary
+                                      id="HeaderDrawer-{{ link.handle }}-{{ childlink.handle }}"
+                                      class="menu-drawer__menu-item link link--text list-menu__item focus-inset"
+                                    >
+                                      {{ childlink.title | escape }}
+                                      <span class="svg-wrapper">
+                                        {{- 'icon-arrow.svg' | inline_asset_content -}}
+                                      </span>
+                                      <span class="svg-wrapper">
+                                        {{- 'icon-caret.svg' | inline_asset_content -}}
+                                      </span>
+                                    </summary>
+                                    <div
+                                      id="childlink-{{ childlink.handle | escape }}"
+                                      class="menu-drawer__submenu has-submenu gradient motion-reduce"
+                                    >
+                                      <button
+                                        class="menu-drawer__close-button link link--text focus-inset"
+                                        aria-expanded="true"
+                                      >
+                                        <span class="svg-wrapper">
+                                          {{- 'icon-arrow.svg' | inline_asset_content -}}
+                                        </span>
+                                        {{ childlink.title | escape }}
+                                      </button>
+                                      <ul
+                                        class="menu-drawer__menu list-menu"
+                                        role="list"
+                                        tabindex="-1"
+                                      >
+                                        {%- for grandchildlink in childlink.links -%}
+                                          <li>
+                                            <a
+                                              id="HeaderDrawer-{{ link.handle }}-{{ childlink.handle }}-{{ grandchildlink.handle }}"
+                                              href="{{ grandchildlink.url }}"
+                                              class="menu-drawer__menu-item link link--text list-menu__item focus-inset{% if grandchildlink.current %} menu-drawer__menu-item--active{% endif %}"
+                                              {% if grandchildlink.current %}
+                                                aria-current="page"
+                                              {% endif %}
+                                            >
+                                              {{ grandchildlink.title | escape }}
+                                            </a>
+                                          </li>
+                                        {%- endfor -%}
+                                      </ul>
+                                    </div>
+                                  </details>
+                                {%- endif -%}
+                              </li>
+                            {%- endfor -%}
+                          </ul>
+                        </div>
+                      </div>
+                    </details>
+                  {%- else -%}
+                    <a
+                      id="HeaderDrawer-{{ link.handle }}"
+                      href="{{ link.url }}"
+                      class="menu-drawer__menu-item list-menu__item link link--text focus-inset{% if link.current %} menu-drawer__menu-item--active{% endif %}"
+                      {% if link.current %}
+                        aria-current="page"
+                      {% endif %}
+                    >
+                      {{ link.title | escape }}
+                    </a>
+                  {%- endif -%}
+                </li>
+              {%- endfor -%}
+              <li><a href="{{ routes.root_url }}#how-it-works" class="menu-drawer__menu-item list-menu__item link link--text focus-inset">How It Works</a></li>
+              <li><a href="{{ routes.root_url }}#pricing" class="menu-drawer__menu-item list-menu__item link link--text focus-inset">Pricing</a></li>
+              <li><a href="{{ routes.root_url }}#testimonials" class="menu-drawer__menu-item list-menu__item link link--text focus-inset">Testimonials</a></li>
+            </ul>
+          </nav>
+          <div class="menu-drawer__utility-links">
+            {%- if localization.available_countries or localization.available_languages -%}
+              <div class="menu-drawer__localization header-localization">
+                {%- if localization.available_countries and localization.available_countries.size > 1 -%}
+                  <localization-form>
+                    {%- form 'localization', id: 'HeaderCountryMobileForm', class: 'localization-form' -%}
+                      <div>
+                        <h2 class="visually-hidden" id="HeaderCountryMobileLabel">
+                          {{ 'localization.country_label' | t }}
+                        </h2>
+                        {%- render 'country-localization', localPosition: 'HeaderCountryMobile' -%}
+                      </div>
+                    {%- endform -%}
+                  </localization-form>
+                {% endif %}
+
+                {%- if localization.available_languages and localization.available_languages.size > 1 -%}
+                  <localization-form>
+                    {%- form 'localization', id: 'HeaderLanguageMobileForm', class: 'localization-form' -%}
+                      <div>
+                        <h2 class="visually-hidden" id="HeaderLanguageMobileLabel">
+                          {{ 'localization.language_label' | t }}
+                        </h2>
+                        {%- render 'language-localization', localPosition: 'HeaderLanguageMobile' -%}
+                      </div>
+                    {%- endform -%}
+                  </localization-form>
+                {%- endif -%}
+              </div>
+            {%- endif -%}
+            <ul class="list list-social list-unstyled" role="list">
+              {%- if settings.social_twitter_link != blank -%}
+                <li class="list-social__item">
+                  <a href="{{ settings.social_twitter_link }}" class="list-social__link link">
+                    <span class="svg-wrapper">
+                      {{- 'icon-twitter.svg' | inline_asset_content -}}
+                    </span>
+                    <span class="visually-hidden">{{ 'general.social.links.twitter' | t }}</span>
+                  </a>
+                </li>
+              {%- endif -%}
+              {%- if settings.social_facebook_link != blank -%}
+                <li class="list-social__item">
+                  <a href="{{ settings.social_facebook_link }}" class="list-social__link link">
+                    <span class="svg-wrapper">
+                      {{- 'icon-facebook.svg' | inline_asset_content -}}
+                    </span>
+                    <span class="visually-hidden">{{ 'general.social.links.facebook' | t }}</span>
+                  </a>
+                </li>
+              {%- endif -%}
+              {%- if settings.social_pinterest_link != blank -%}
+                <li class="list-social__item">
+                  <a href="{{ settings.social_pinterest_link }}" class="list-social__link link">
+                    <span class="svg-wrapper">
+                      {{- 'icon-pinterest.svg' | inline_asset_content -}}
+                    </span>
+                    <span class="visually-hidden">{{ 'general.social.links.pinterest' | t }}</span>
+                  </a>
+                </li>
+              {%- endif -%}
+              {%- if settings.social_instagram_link != blank -%}
+                <li class="list-social__item">
+                  <a href="{{ settings.social_instagram_link }}" class="list-social__link link">
+                    <span class="svg-wrapper">
+                      {{- 'icon-instagram.svg' | inline_asset_content -}}
+                    </span>
+                    <span class="visually-hidden">{{ 'general.social.links.instagram' | t }}</span>
+                  </a>
+                </li>
+              {%- endif -%}
+              {%- if settings.social_tiktok_link != blank -%}
+                <li class="list-social__item">
+                  <a href="{{ settings.social_tiktok_link }}" class="list-social__link link">
+                    <span class="svg-wrapper">
+                      {{- 'icon-tiktok.svg' | inline_asset_content -}}
+                    </span>
+                    <span class="visually-hidden">{{ 'general.social.links.tiktok' | t }}</span>
+                  </a>
+                </li>
+              {%- endif -%}
+              {%- if settings.social_tumblr_link != blank -%}
+                <li class="list-social__item">
+                  <a href="{{ settings.social_tumblr_link }}" class="list-social__link link">
+                    <span class="svg-wrapper">
+                      {{- 'icon-tumblr.svg' | inline_asset_content -}}
+                    </span>
+                    <span class="visually-hidden">{{ 'general.social.links.tumblr' | t }}</span>
+                  </a>
+                </li>
+              {%- endif -%}
+              {%- if settings.social_snapchat_link != blank -%}
+                <li class="list-social__item">
+                  <a href="{{ settings.social_snapchat_link }}" class="list-social__link link">
+                    <span class="svg-wrapper">
+                      {{- 'icon-snapchat.svg' | inline_asset_content -}}
+                    </span>
+                    <span class="visually-hidden">{{ 'general.social.links.snapchat' | t }}</span>
+                  </a>
+                </li>
+              {%- endif -%}
+              {%- if settings.social_youtube_link != blank -%}
+                <li class="list-social__item">
+                  <a href="{{ settings.social_youtube_link }}" class="list-social__link link">
+                    <span class="svg-wrapper">
+                      {{- 'icon-youtube.svg' | inline_asset_content -}}
+                    </span>
+                    <span class="visually-hidden">{{ 'general.social.links.youtube' | t }}</span>
+                  </a>
+                </li>
+              {%- endif -%}
+              {%- if settings.social_vimeo_link != blank -%}
+                <li class="list-social__item">
+                  <a href="{{ settings.social_vimeo_link }}" class="list-social__link link">
+                    <span class="svg-wrapper">
+                      {{- 'icon-vimeo.svg' | inline_asset_content -}}
+                    </span>
+                    <span class="visually-hidden">{{ 'general.social.links.vimeo' | t }}</span>
+                  </a>
+                </li>
+              {%- endif -%}
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </details>
+</header-drawer>
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    var drawer = document.getElementById('Details-menu-drawer-container');
+    if (!drawer) return;
+    drawer.querySelectorAll('a').forEach(function (link) {
+      link.addEventListener('click', function () {
+        drawer.removeAttribute('open');
+      });
+    });
+  });
+</script>

--- a/theme/snippets/header-drawer.liquid
+++ b/theme/snippets/header-drawer.liquid
@@ -270,10 +270,12 @@
   document.addEventListener('DOMContentLoaded', function () {
     var drawer = document.getElementById('Details-menu-drawer-container');
     if (!drawer) return;
+    var toggle = drawer.querySelector('summary');
     drawer.querySelectorAll('a').forEach(function (link) {
       link.addEventListener('click', function () {
-        drawer.removeAttribute('open');
+        if (drawer.hasAttribute('open')) {
+          toggle.dispatchEvent(new Event('click'));
+        }
       });
     });
-  });
-</script>
+  });</script>

--- a/theme/snippets/header-dropdown-menu.liquid
+++ b/theme/snippets/header-dropdown-menu.liquid
@@ -1,0 +1,106 @@
+{% comment %}
+  Renders a standard dropdown style menu for the header.
+
+  Usage:
+  {% render 'header-dropdown-menu' %}
+{% endcomment %}
+
+<nav class="small-hide header__inline-menu main-navbar">
+  <ul class="list-menu list-menu--inline" role="list">
+    {%- for link in section.settings.menu.links -%}
+      <li>
+        {%- if link.links != blank -%}
+          <header-menu>
+            <details id="Details-HeaderMenu-{{ forloop.index }}">
+              <summary
+                id="HeaderMenu-{{ link.handle }}"
+                class="header__menu-item list-menu__item link focus-inset"
+              >
+                <span
+                  {%- if link.child_active %}
+                    class="header__active-menu-item"
+                  {% endif %}
+                >
+                  {{- link.title | escape -}}
+                </span>
+                {{- 'icon-caret.svg' | inline_asset_content -}}
+              </summary>
+              <ul
+                id="HeaderMenu-MenuList-{{ forloop.index }}"
+                class="header__submenu list-menu list-menu--disclosure color-{{ section.settings.menu_color_scheme }} gradient caption-large motion-reduce global-settings-popup"
+                role="list"
+                tabindex="-1"
+              >
+                {%- for childlink in link.links -%}
+                  <li>
+                    {%- if childlink.links == blank -%}
+                      <a
+                        id="HeaderMenu-{{ link.handle }}-{{ childlink.handle }}"
+                        href="{{ childlink.url }}"
+                        class="header__menu-item list-menu__item link link--text focus-inset caption-large{% if childlink.current %} list-menu__item--active{% endif %}"
+                        {% if childlink.current %}
+                          aria-current="page"
+                        {% endif %}
+                      >
+                        {{ childlink.title | escape }}
+                      </a>
+                    {%- else -%}
+                      <details id="Details-HeaderSubMenu-{{ link.handle }}-{{ childlink.handle }}">
+                        <summary
+                          id="HeaderMenu-{{ link.handle }}-{{ childlink.handle }}"
+                          class="header__menu-item link link--text list-menu__item focus-inset caption-large"
+                        >
+                          <span>{{ childlink.title | escape }}</span>
+                          {{- 'icon-caret.svg' | inline_asset_content -}}
+                        </summary>
+                        <ul
+                          id="HeaderMenu-SubMenuList-{{ link.handle }}-{{ childlink.handle }}-{{ grandchildlink.handle }}"
+                          class="header__submenu list-menu motion-reduce"
+                        >
+                          {%- for grandchildlink in childlink.links -%}
+                            <li>
+                              <a
+                                id="HeaderMenu-{{ link.handle }}-{{ childlink.handle }}-{{ grandchildlink.handle }}"
+                                href="{{ grandchildlink.url }}"
+                                class="header__menu-item list-menu__item link link--text focus-inset caption-large{% if grandchildlink.current %} list-menu__item--active{% endif %}"
+                                {% if grandchildlink.current %}
+                                  aria-current="page"
+                                {% endif %}
+                              >
+                                {{ grandchildlink.title | escape }}
+                              </a>
+                            </li>
+                          {%- endfor -%}
+                        </ul>
+                      </details>
+                    {%- endif -%}
+                  </li>
+                {%- endfor -%}
+              </ul>
+            </details>
+          </header-menu>
+        {%- else -%}
+          <a
+            id="HeaderMenu-{{ link.handle }}"
+            href="{{ link.url }}"
+            class="header__menu-item list-menu__item link link--text focus-inset"
+            {% if link.current %}
+              aria-current="page"
+            {% endif %}
+          >
+            <span
+              {%- if link.current %}
+                class="header__active-menu-item"
+              {% endif %}
+            >
+              {{- link.title | escape -}}
+            </span>
+          </a>
+        {%- endif -%}
+      </li>
+    {%- endfor -%}
+    <li><a href="{{ routes.root_url }}#how-it-works" class="header__menu-item list-menu__item link link--text focus-inset">How It Works</a></li>
+    <li><a href="{{ routes.root_url }}#pricing" class="header__menu-item list-menu__item link link--text focus-inset">Pricing</a></li>
+    <li><a href="{{ routes.root_url }}#testimonials" class="header__menu-item list-menu__item link link--text focus-inset">Testimonials</a></li>
+  </ul>
+</nav>

--- a/theme/snippets/header-mega-menu.liquid
+++ b/theme/snippets/header-mega-menu.liquid
@@ -1,0 +1,97 @@
+{% comment %}
+  Renders a megamenu for the header.
+
+  Usage:
+  {% render 'header-mega-menu' %}
+{% endcomment %}
+
+<nav class="small-hide header__inline-menu main-navbar">
+  <ul class="list-menu list-menu--inline" role="list">
+    {%- for link in section.settings.menu.links -%}
+      <li>
+        {%- if link.links != blank -%}
+          <header-menu>
+            <details id="Details-HeaderMenu-{{ forloop.index }}" class="mega-menu">
+              <summary
+                id="HeaderMenu-{{ link.handle }}"
+                class="header__menu-item list-menu__item link focus-inset"
+              >
+                <span
+                  {%- if link.child_active %}
+                    class="header__active-menu-item"
+                  {% endif %}
+                >
+                  {{- link.title | escape -}}
+                </span>
+                {{- 'icon-caret.svg' | inline_asset_content -}}
+              </summary>
+              <div
+                id="MegaMenu-Content-{{ forloop.index }}"
+                class="mega-menu__content color-{{ section.settings.menu_color_scheme }} gradient motion-reduce global-settings-popup"
+                tabindex="-1"
+              >
+                <ul
+                  class="mega-menu__list page-width{% if link.levels == 1 %} mega-menu__list--condensed{% endif %}"
+                  role="list"
+                >
+                  {%- for childlink in link.links -%}
+                    <li>
+                      <a
+                        id="HeaderMenu-{{ link.handle }}-{{ childlink.handle }}"
+                        href="{{ childlink.url }}"
+                        class="mega-menu__link mega-menu__link--level-2 link{% if childlink.current %} mega-menu__link--active{% endif %}"
+                        {% if childlink.current %}
+                          aria-current="page"
+                        {% endif %}
+                      >
+                        {{ childlink.title | escape }}
+                      </a>
+                      {%- if childlink.links != blank -%}
+                        <ul class="list-unstyled" role="list">
+                          {%- for grandchildlink in childlink.links -%}
+                            <li>
+                              <a
+                                id="HeaderMenu-{{ link.handle }}-{{ childlink.handle }}-{{ grandchildlink.handle }}"
+                                href="{{ grandchildlink.url }}"
+                                class="mega-menu__link link{% if grandchildlink.current %} mega-menu__link--active{% endif %}"
+                                {% if grandchildlink.current %}
+                                  aria-current="page"
+                                {% endif %}
+                              >
+                                {{ grandchildlink.title | escape }}
+                              </a>
+                            </li>
+                          {%- endfor -%}
+                        </ul>
+                      {%- endif -%}
+                    </li>
+                  {%- endfor -%}
+                </ul>
+              </div>
+            </details>
+          </header-menu>
+        {%- else -%}
+          <a
+            id="HeaderMenu-{{ link.handle }}"
+            href="{{ link.url }}"
+            class="header__menu-item list-menu__item link link--text focus-inset"
+            {% if link.current %}
+              aria-current="page"
+            {% endif %}
+          >
+            <span
+              {%- if link.current %}
+                class="header__active-menu-item"
+              {% endif %}
+            >
+              {{- link.title | escape -}}
+            </span>
+          </a>
+        {%- endif -%}
+      </li>
+    {%- endfor -%}
+    <li><a href="{{ routes.root_url }}#how-it-works" class="header__menu-item list-menu__item link link--text focus-inset">How It Works</a></li>
+    <li><a href="{{ routes.root_url }}#pricing" class="header__menu-item list-menu__item link link--text focus-inset">Pricing</a></li>
+    <li><a href="{{ routes.root_url }}#testimonials" class="header__menu-item list-menu__item link link--text focus-inset">Testimonials</a></li>
+  </ul>
+</nav>


### PR DESCRIPTION
## Summary
- create `header-mega-menu.liquid` snippet with `small-hide` so the inline menu disappears on small screens
- do the same for `header-dropdown-menu.liquid`
- add CSS to `header.liquid` so icons and menus stay hidden on phones
- remove login link from `header-drawer.liquid` so only social and localization links remain
- clean out stray search icon so it doesn't appear on desktop
- close the mobile drawer when clicking any link

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_b_686bdebcf8e88325854284716f1a2526