### PR TITLE
Add search and expandable tutor list to teacher select page

### DIFF
--- a/sections/teacher-select.liquid
+++ b/sections/teacher-select.liquid
@@ -1,0 +1,330 @@
+<section class="teacher-select-bg">
+  <div class="teacher-select page-width">
+    <div class="teacher-select__main">
+      <div class="teacher-select__content">
+        <h1>{{ section.settings.heading }}</h1>
+        <p>{{ section.settings.subheading }}</p>
+        <input type="text" id="tutorSearch" class="tutor-search" placeholder="Search teachers...">
+        <div class="tutors-list">
+          {% for block in section.blocks %}
+            <div class="tutor-option">
+              <input type="radio" id="tutor-{{ forloop.index }}" name="teacher" value="{{ block.settings.name }}" class="tutor-radio" {% if forloop.first %}checked{% endif %}>
+              <label for="tutor-{{ forloop.index }}" class="tutor-card">
+                <div class="tutor-info">
+                  <h4 class="tutor-name">{{ block.settings.name }}</h4>
+                  <p class="tutor-desc">{{ block.settings.description }}</p>
+                </div>
+              </label>
+            </div>
+          {% endfor %}
+        </div>
+        <button id="showMoreTutors" class="show-more" aria-label="Show more tutors">&#x25BC;</button>
+      </div>
+      <div class="teacher-select__visual">
+        <img class="teacher-select__image" src="" alt="">
+        <div class="package-box">
+          <div class="cart-title">Your Selection</div>
+          <div class="cart-package"><strong>{{ section.settings.package_name }}</strong></div>
+          <div class="cart-plan">{{ section.settings.package_plan }}</div>
+          <div class="cart-price">{{ section.settings.package_price }}</div>
+          <a href="{{ section.settings.continue_url }}" id="continueBtn" class="button checkout-mat">Continue</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const params = new URLSearchParams(window.location.search);
+  const pkg = params.get('package') || 'private-tutoring';
+  const duration = params.get('duration') || 'monthly';
+  const durationMap = { monthly: 'Monthly', quarterly: '3-Month', yearly: '12-Month' };
+  const priceTable = {
+    'private-tutoring': { monthly: '$199.99', quarterly: '$179.99', yearly: '$119.99' },
+    'small-group': { monthly: '$79.99', quarterly: '$69.99', yearly: '$49.99' },
+    'group-classes': { monthly: '$49.99', quarterly: '$44.99', yearly: '$29.99' }
+  };
+  const plan = durationMap[duration] || 'Monthly';
+  const price = (priceTable[pkg] && priceTable[pkg][duration]) || priceTable['private-tutoring'].monthly;
+
+  const packageImage = 'https://cdn.shopify.com/s/files/1/0759/1546/0848/files/ChatGPT_Image_10_Tem_2025_12_58_03.png?v=1752142931';
+  const nameMap = {
+    'private-tutoring': 'Private Tutoring',
+    'small-group': 'Small Group',
+    'group-classes': 'Group Classes'
+  };
+
+  document.querySelector('.teacher-select__image').src = packageImage;
+  document.querySelector('.cart-package').innerHTML = `<strong>${nameMap[pkg] || ''}</strong>`;
+  document.querySelector('.cart-plan').textContent = plan;
+  document.querySelector('.cart-price').textContent = price;
+  const tutorOptions = Array.from(document.querySelectorAll('.tutor-option'));
+  const showMoreBtn = document.getElementById('showMoreTutors');
+  const searchInput = document.getElementById('tutorSearch');
+  const initialVisible = 2;
+  let expanded = false;
+
+  function updateVisibility() {
+    tutorOptions.forEach((opt, idx) => {
+      opt.style.display = expanded || idx < initialVisible ? '' : 'none';
+    });
+    showMoreBtn.style.display = expanded || tutorOptions.length <= initialVisible ? 'none' : '';
+  }
+
+  updateVisibility();
+
+  showMoreBtn.addEventListener('click', function() {
+    expanded = true;
+    updateVisibility();
+  });
+
+  searchInput.addEventListener('input', function() {
+    const query = this.value.toLowerCase();
+    if (query) {
+      tutorOptions.forEach(opt => {
+        const name = opt.querySelector('.tutor-name').textContent.toLowerCase();
+        opt.style.display = name.includes(query) ? '' : 'none';
+      });
+      showMoreBtn.style.display = 'none';
+    } else {
+      expanded = false;
+      updateVisibility();
+    }
+  });
+
+  const btn = document.getElementById('continueBtn');
+  const base = `/pages/${pkg}`;
+  const continueUrl = new URL(base, window.location.origin);
+  continueUrl.searchParams.set('duration', duration);
+  btn.setAttribute('href', continueUrl.toString());
+  btn.addEventListener('click', function(e) {
+    e.preventDefault();
+    const sel = document.querySelector('.tutor-radio:checked');
+    if (sel) {
+      const url = new URL(btn.getAttribute('href'), window.location.origin);
+      url.searchParams.set('teacher', sel.value);
+      window.location.href = url.toString();
+    } else {
+      alert('Please select a teacher');
+    }
+  });
+});
+</script>
+
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap');
+.teacher-select-bg {
+  background: linear-gradient(105deg, #ffffff 60%, #e7e9fb 100%);
+  padding-top: 40px;
+  padding-bottom: 40px;
+}
+.teacher-select {
+  max-width: 1160px;
+  margin: 0 auto;
+  padding: 0 12px;
+}
+.teacher-select__main {
+  display: flex;
+  gap: 40px;
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+.teacher-select__content {
+  flex: 2 1 430px;
+  min-width: 320px;
+  max-width: 820px;
+  padding: 2.3rem 1.3rem 2.1rem 0;
+}
+.teacher-select__content h1 {
+  font-size: 2.4rem;
+  font-weight: 800;
+  color: #21264b;
+  margin-bottom: 0.8rem;
+}
+.teacher-select__content p {
+  font-size: 1.2rem;
+  color: #31315b;
+  margin-bottom: 1.3rem;
+}
+.tutor-search {
+  width: 100%;
+  max-width: 400px;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  margin-bottom: 1rem;
+  box-sizing: border-box;
+}
+.tutors-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.tutor-option {
+  position: relative;
+}
+.show-more {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 2rem;
+  color: #4e54c8;
+  margin: 0.5rem auto 0;
+  display: block;
+}
+.tutor-radio {
+  display: none;
+}
+.tutor-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  width: 791px;
+  height: 216px;
+  max-width: 100%;
+  box-sizing: border-box;
+  margin: 0 auto;
+  padding: 1rem;
+  cursor: pointer;
+  background: rgba(78, 84, 200, 0.05);
+  border: 2px solid rgba(78, 84, 200, 0.2);
+  border-radius: 8px;
+  transition: background 0.2s, box-shadow 0.2s, border-color 0.2s;
+}
+.tutor-card .tutor-info {
+  font-size: 1.6rem;
+  line-height: 1.4;
+  color: #21264b;
+  font-family: 'Poppins', sans-serif;
+}
+.tutor-name { font-size: 2rem; font-weight: 600; }
+.tutor-radio:checked + .tutor-card {
+  background: rgba(78, 84, 200, 0.15);
+  border-color: rgba(78, 84, 200, 0.8);
+  box-shadow: 0 0 0 3px rgba(78, 84, 200, 0.5);
+}
+.teacher-select__visual {
+  flex: 1 1 380px;
+  min-width: 290px;
+  max-width: 420px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 11rem;
+  gap: 2.1rem;
+}
+.teacher-select__image {
+  width: 100%;
+  max-width: 340px;
+  object-fit: cover;
+  background: #f8fafc;
+  margin-bottom: 0.5rem;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+}
+.package-box {
+  width: 100%;
+  max-width: 340px;
+  padding: 2rem 1.6rem 1.5rem 1.6rem;
+  background: #fff;
+  border: 1.5px solid #e4e7f0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  margin-top: 0;
+  margin-bottom: 1.15rem;
+}
+.cart-title {
+  font-size: 1.12rem;
+  font-weight: 700;
+  color: #4e54c8;
+  margin-bottom: 0.7rem;
+}
+.cart-package { font-size: 1.09rem; font-weight: 600; color: #23235b; margin-bottom: 0.3rem; }
+.cart-plan { margin-bottom: 0.3rem; font-size: 1.01rem; color: #28305e; }
+.cart-price { font-size: 1.28rem; font-weight: 800; color: #4e54c8; margin-bottom: 1rem; }
+.button.checkout-mat {
+  margin-top: 16px;
+  display: block;
+  width: 100%;
+  max-width: 340px;
+  height: 56px;
+  line-height: 56px;
+  text-align: center;
+  font-size: 1.2rem;
+  font-weight: 700;
+  background: #fff;
+  color: #4e54c8;
+  border: 2px solid #4e54c8;
+  border-radius: 0;
+  box-shadow: none;
+  cursor: pointer;
+  letter-spacing: 0.01em;
+  outline: none;
+  position: relative;
+  overflow: hidden;
+  transition: color 0.18s, border-color 0.22s, background 0.20s;
+}
+.button.checkout-mat:after {
+  content: "";
+  position: absolute;
+  top: 0; left: -60px;
+  width: 45px; height: 100%;
+  background: linear-gradient(100deg,rgba(76,107,255,0.12) 0%,rgba(80,100,250,0.13) 65%,rgba(255,255,255,0.03) 100%);
+  opacity: 1;
+  transition: left 0.33s;
+  pointer-events: none;
+}
+.button.checkout-mat:hover:after {
+  left: 110%;
+  transition: left 0.55s;
+}
+.button.checkout-mat:hover, .button.checkout-mat:focus {
+  background: #f4f7ff;
+  color: #3149cc;
+  border-color: #3149cc;
+  box-shadow: 0 6px 18px rgba(90,110,220,0.06);
+  transform: translateY(-2px) scale(1.017);
+}
+@media (max-width: 900px) {
+  .teacher-select__main { flex-direction: column; gap: 22px; }
+  .teacher-select__visual { flex-direction: row; gap: 1.5rem; justify-content: flex-start; margin-top: 0; }
+  .teacher-select__image, .package-box, .button.checkout-mat { max-width: 48vw; }
+  .teacher-select__content { max-width: 100%; padding: 1.5rem 0.5rem 1.2rem 0.5rem; }
+}
+@media (max-width: 600px) {
+  .teacher-select__visual { flex-direction: column; align-items: center; }
+  .teacher-select__image, .package-box, .button.checkout-mat { max-width: 100%; }
+  .package-box { padding: 1.3rem 0.8rem; }
+}
+</style>
+
+{% schema %}
+{
+  "name": "Teacher Selection",
+  "settings": [
+    {"type": "text", "id": "heading", "label": "Heading", "default": "Choose Your Teacher"},
+    {"type": "text", "id": "subheading", "label": "Subheading", "default": "Select a tutor and continue"},
+    {"type": "text", "id": "package_name", "label": "Package Name", "default": "Private Tutoring"},
+    {"type": "text", "id": "package_plan", "label": "Plan", "default": "Monthly"},
+    {"type": "text", "id": "package_price", "label": "Price", "default": "$0"},
+    {"type": "url", "id": "continue_url", "label": "Continue URL", "default": "/"}
+  ],
+  "blocks": [
+    {
+      "type": "teacher",
+      "name": "Teacher",
+      "settings": [
+        {"type": "text", "id": "name", "label": "Name"},
+        {"type": "textarea", "id": "description", "label": "Description"}
+      ]
+    }
+  ],
+  "presets": [
+    {"name": "Teacher Selection", "category": "Custom"}
+  ]
+}
+{% endschema %}


### PR DESCRIPTION
## Summary
- Add search field and expandable arrow to select teachers on the teacher-select section
- Implement client-side logic to filter tutors and reveal hidden options
- Style new search box and show-more button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689878630ca483298f1eafabf3dd6c20